### PR TITLE
Fix download buttons for Adobe swatches

### DIFF
--- a/content/docs/swatches/index.mdx
+++ b/content/docs/swatches/index.mdx
@@ -34,14 +34,14 @@ There are two different color swatches available for _Adobe_ products like [Phot
 
 - `.aco` — A format especially designed for and only compatible with _Adobe Photoshop_.
   <SpaceBox mTop={2} mBottom={2}>
-    <Button href="https://raw.githubusercontent.com/arcticicestudio/nord/develop/src/swatches/nord.ase">
-      Download Nord for Adobe Swatch Exchange
+    <Button href="https://raw.githubusercontent.com/arcticicestudio/nord/develop/src/swatches/nord.aco">
+      Download Nord for Adobe Photoshop
     </Button>
   </SpaceBox>
 - `.ase` — The “_Adobe Swatch Exchange_“ format that allows to share color swatches between different _Adobe_ products.
   <SpaceBox mTop={2} mBottom={2}>
-    <Button href="https://raw.githubusercontent.com/arcticicestudio/nord/develop/src/swatches/nord.aco">
-      Download Nord for Adobe Photoshop
+    <Button href="https://raw.githubusercontent.com/arcticicestudio/nord/develop/src/swatches/nord.ase">
+      Download Nord for Adobe Swatch Exchange
     </Button>
   </SpaceBox>
 


### PR DESCRIPTION
In [Swatches page](https://www.nordtheme.com/docs/swatches), download button for .ase file is located in the .aco
section, and button for .aco in .ase section.