### PR TITLE
Fix typo in hero link for lightline on vim page

### DIFF
--- a/src/components/organisms/page/ports/vim/SectionHero/SectionHero.jsx
+++ b/src/components/organisms/page/ports/vim/SectionHero/SectionHero.jsx
@@ -47,7 +47,7 @@ const SectionHero = ({ assets }) => {
             <Subline>
               Build for Vim&apos;s terminal- and GUI mode with <em>true colors</em> and support for many third-party
               syntax and UI plugins including bundled themes for{" "}
-              <Link href="https://github.com/itchyny/lightline.vim">lighline.vim</Link> and{" "}
+              <Link href="https://github.com/itchyny/lightline.vim">lightline.vim</Link> and{" "}
               <Link href="https://github.com/vim-airline/vim-airline">vim-airline</Link>.
             </Subline>
             <Actions>


### PR DESCRIPTION
> Fixes #164 

This will fix the missing letter `t` in the hero link for lightline.

Reference: [https://www.nordtheme.com/ports/vim](https://www.nordtheme.com/ports/vim)