### PR TITLE
Fix typo in vim plugin support section

### DIFF
--- a/src/components/organisms/page/ports/vim/SectionPluginSupport/SectionPluginSupport.jsx
+++ b/src/components/organisms/page/ports/vim/SectionPluginSupport/SectionPluginSupport.jsx
@@ -106,8 +106,7 @@ const SectionPluginSupport = ({ assets }) => (
         </Visualization>
         <Text>
           <Subline>
-            Beautiful syntax highlighting with support for gr
-            <Link href="https://github.com/fatih/vim-go">vim-go</Link> and{" "}
+            Beautiful syntax highlighting with support for <Link href="https://github.com/fatih/vim-go">vim-go</Link>{" "}
             <Link href="https://github.com/vim-airline/vim-airline">vim-airline</Link>.
           </Subline>
         </Text>

--- a/src/components/organisms/page/ports/vim/SectionPluginSupport/SectionPluginSupport.jsx
+++ b/src/components/organisms/page/ports/vim/SectionPluginSupport/SectionPluginSupport.jsx
@@ -107,7 +107,7 @@ const SectionPluginSupport = ({ assets }) => (
         <Text>
           <Subline>
             Beautiful syntax highlighting with support for <Link href="https://github.com/fatih/vim-go">vim-go</Link>{" "}
-            <Link href="https://github.com/vim-airline/vim-airline">vim-airline</Link>.
+            and <Link href="https://github.com/vim-airline/vim-airline">vim-airline</Link>.
           </Subline>
         </Text>
       </FeatureDuo>


### PR DESCRIPTION
Removing additional `gr` before vim-go link

https://www.nordtheme.com/ports/vim
