### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,7 @@
-MIT License (MIT)
+MIT License
 
-<!-- lint disable no-auto-link-without-protocol -->
-
-Copyright (C) 2018-present Arctic Ice Studio <development@arcticicestudio.com> (https://arcticicestudio.com)  
+Copyright (C) 2018-present Arctic Ice Studio <development@arcticicestudio.com> (https://arcticicestudio.com)
 Copyright (C) 2018-present Sven Greb <development@svengreb.de> (https://svengreb.de)
-
-<!-- lint enable no-auto-link-without-protocol -->
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Remove file extenstion so it isn't linted
Remove linting ignore statements
Copy exact text from: https://choosealicense.com/licenses/mit/

This will allow GitHub to display "MIT" as the license instead
of just showing "View license"