### PR TITLE
Improve the grammar of the subheading on the landing page

### DIFF
--- a/src/components/organisms/page/landing/SectionHero/SectionHero.jsx
+++ b/src/components/organisms/page/landing/SectionHero/SectionHero.jsx
@@ -60,7 +60,7 @@ export default class SectionHero extends PureComponent {
                 An arctic, north-bluish color palette.
               </Headline>
               <Subline>
-                Created for the clean and uncluttered design pattern to achieve a optimal focus and readability for code
+                Created for a clean and uncluttered design pattern to achieve optimal focus and readability for code
                 syntax highlighting and UI components.
               </Subline>
               <Actions>


### PR DESCRIPTION
Fixed a typo on the subline of the landing page.